### PR TITLE
Refacto back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ test-result
 /server/tmp/
 /server/log/
 /server/storage/
+cumulus-log/
+

--- a/server/app/io/cumulus/controllers/utils/FileDownloaderUtils.scala
+++ b/server/app/io/cumulus/controllers/utils/FileDownloaderUtils.scala
@@ -7,6 +7,7 @@ import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import io.cumulus.core.stream.storage.StorageReferenceReader
 import io.cumulus.core.utils.Range
+import io.cumulus.core.validation.AppError
 import io.cumulus.models.fs.File
 import io.cumulus.persistence.storage.StorageEngine
 import play.api.http.HttpEntity
@@ -15,22 +16,27 @@ import play.api.mvc.{Request, Result}
 
 trait FileDownloaderUtils {
 
-  protected def headerRange(request: Request[_], file: File): Range = {
-    val headerRange: (Long, Long) =
-      request.headers.get("Range").getOrElse("bytes=0-").split('=').toList match {
-        case "bytes" :: r :: Nil => r.split('-').map(_.toLong).toList match {
-          case from :: to :: Nil => (from, to)
-          case from :: Nil => (from, -1)
-          case _ => (0, -1)
-        }
-        case _ => (0, -1)
-      }
+  protected def headerRange(request: Request[_], file: File): Either[AppError, Range] = {
 
-    // TODO check validity & return 406 if not
-    Range(
-      headerRange._1,
-      if(headerRange._2 > 0) headerRange._2 else file.size - 1
-    )
+    val range = request.headers.get("Range").getOrElse("bytes=0-").split('=').toList match {
+      case "bytes" :: r :: Nil => r.split('-').map(_.toLong).toList match {
+        case from :: to :: Nil => Range(from, to)
+        case from :: Nil => Range(from, file.size - 1)
+        case _ => Range(0, file.size - 1)
+      }
+      case _ => Range(0, file.size - 1)
+    }
+
+    range match {
+      case Range(_, to) if to > (file.size - 1) =>
+        AppError.notAcceptable("validation.range.range-outside-end")
+      case Range(from, _) if from < 0 =>
+        AppError.notAcceptable("validation.range.range-outside-start")
+      case Range(from, to) if to < from =>
+        AppError.notAcceptable("validation.range.range-negative")
+      case validRange =>
+        Right(validRange)
+    }
   }
 
   protected def downloadFile(

--- a/server/app/io/cumulus/core/controllers/utils/authentication/Authentication.scala
+++ b/server/app/io/cumulus/core/controllers/utils/authentication/Authentication.scala
@@ -8,6 +8,7 @@ import pdi.jwt.JwtSession
 import play.api.i18n.I18nSupport
 import play.api.libs.json.{Format, Writes}
 import play.api.mvc._
+import Authentication._
 
 /**
   * Authentication trait using JWT. Needs to be extends by a controller which wants to use authentication.
@@ -50,8 +51,6 @@ import play.api.mvc._
   *              `Writes[USER]` must be in the scope of the controller.
   */
 trait Authentication[USER] extends BaseController with I18nSupport {
-
-  import Authentication._
 
   case class AuthenticatedRequest[A](user: USER, request: Request[A]) extends WrappedRequest[A](request)
 
@@ -124,9 +123,9 @@ trait Authentication[USER] extends BaseController with I18nSupport {
 
         override def invokeBlock[A](request: Request[A], block: (AuthenticatedRequest[A]) => Future[Result]) = {
           val jwtSession =
-            JwtSession.deserialize(request.cookies.get(COOKIE_NAME).getOrElse(Cookie(COOKIE_NAME, "")).value)
+            JwtSession.deserialize(request.cookies.get(cookieName).getOrElse(Cookie(cookieName, "")).value)
 
-          jwtSession.getAs[USER](TOKEN_FIELD).map(AuthenticatedRequest(_, request)) match {
+          jwtSession.getAs[USER](tokenField).map(AuthenticatedRequest(_, request)) match {
             case Some(authenticatedRequest) => block(authenticatedRequest).map(_.withAuthentication(jwtSession))
             case None                       => errorHandler(request)
           }
@@ -155,14 +154,14 @@ trait Authentication[USER] extends BaseController with I18nSupport {
     * @param payload The payload of the token
     */
   protected def createJwtSession(payload: USER)(implicit writes: Writes[USER]): JwtSession =
-    JwtSession() + (TOKEN_FIELD, payload)
+    JwtSession() + (tokenField, payload)
 
 }
 
 object Authentication {
 
-  val TOKEN_FIELD = "content"
-  val COOKIE_NAME = "auth"
+  val tokenField = "content"
+  val cookieName = "auth"
 
   implicit class AuthResult(val result: Result) extends AnyVal {
 
@@ -171,13 +170,13 @@ object Authentication {
       * @param jwtSession The JWT session to serialize
       */
     def withAuthentication(jwtSession: JwtSession): Result =
-      result.withCookies(Cookie(Authentication.COOKIE_NAME, jwtSession.refresh().serialize))
+      result.withCookies(Cookie(Authentication.cookieName, jwtSession.refresh().serialize))
 
     /**
       * Remove the cookie containing the aforementioned session
       */
     def withoutAuthentication: Result =
-      result.discardingCookies(DiscardingCookie(Authentication.COOKIE_NAME))
+      result.discardingCookies(DiscardingCookie(Authentication.cookieName))
 
   }
 }

--- a/server/app/io/cumulus/core/stream/storage/StorageReferenceWriter.scala
+++ b/server/app/io/cumulus/core/stream/storage/StorageReferenceWriter.scala
@@ -4,6 +4,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import akka.NotUsed
 import akka.stream.FlowShape
+import akka.stream.scaladsl.GraphDSL.Implicits._
 import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Sink, ZipWith}
 import akka.util.ByteString
 import io.cumulus.core.Settings
@@ -58,8 +59,6 @@ object StorageReferenceWriter {
             storage = storageRef
           )
       })
-
-      import GraphDSL.Implicits._
 
       // Compute the size and hash of the file while writing it using the provided storage engine
       broadcast ~> objectsWriter ~> groupObjects ~> zip.in0

--- a/server/app/io/cumulus/core/validation/AppError.scala
+++ b/server/app/io/cumulus/core/validation/AppError.scala
@@ -15,16 +15,16 @@ sealed trait AppError {
 object AppError {
 
   def notFound(key: String, args: String*): AppError =
-    GlobalError(AppErrorType.NOT_FOUND, key, args: _*)
+    GlobalError(AppErrorType.NotFound, key, args: _*)
 
   def unauthorized(key: String, args: String*): AppError =
-    GlobalError(AppErrorType.UNAUTHORIZED, key, args: _*)
+    GlobalError(AppErrorType.Unauthorized, key, args: _*)
 
   def forbidden(key: String, args: String*): AppError =
-    GlobalError(AppErrorType.FORBIDDEN, key, args: _*)
+    GlobalError(AppErrorType.Forbidden, key, args: _*)
 
   def validation(key: String, args: String*): AppError =
-    GlobalError(AppErrorType.VALIDATION, key, args: _*)
+    GlobalError(AppErrorType.Validation, key, args: _*)
 
   def validation(errors: NonEmptyList[FieldValidationError]): AppError =
     ValidationError(errors)
@@ -36,10 +36,10 @@ object AppError {
     validation(FieldValidationError(path, key, args: _*))
 
   def notAcceptable(key: String, args: String*): AppError =
-    GlobalError(AppErrorType.NOT_ACCEPTABLE, key, args: _*)
+    GlobalError(AppErrorType.NotAcceptable, key, args: _*)
 
   def technical(key: String, args: String*): AppError =
-    GlobalError(AppErrorType.TECHNICAL, key, args: _*)
+    GlobalError(AppErrorType.Technical, key, args: _*)
 
   /**
     * Error are almost always used as left. Use this implicit conversion to simply return an error where
@@ -69,7 +69,7 @@ object FieldValidationError {
   * Validation error, composed of multiple errors
   */
 case class ValidationError(errors: NonEmptyList[FieldValidationError]) extends AppError {
-  val errorType: AppErrorType = AppErrorType.VALIDATION
+  val errorType: AppErrorType = AppErrorType.Validation
 }
 
 /**

--- a/server/app/io/cumulus/core/validation/AppError.scala
+++ b/server/app/io/cumulus/core/validation/AppError.scala
@@ -35,6 +35,9 @@ object AppError {
   def validation(path: JsPath, key: String, args: String*): AppError =
     validation(FieldValidationError(path, key, args: _*))
 
+  def notAcceptable(key: String, args: String*): AppError =
+    GlobalError(AppErrorType.NOT_ACCEPTABLE, key, args: _*)
+
   def technical(key: String, args: String*): AppError =
     GlobalError(AppErrorType.TECHNICAL, key, args: _*)
 

--- a/server/app/io/cumulus/core/validation/AppErrorType.scala
+++ b/server/app/io/cumulus/core/validation/AppErrorType.scala
@@ -24,6 +24,9 @@ object AppErrorType extends Enum[AppErrorType] {
   /** Used when the information provided are invalid */
   case object VALIDATION extends AppErrorType(Results.BadRequest)
 
+  /** Used when the information provided are not acceptable (i.e. invalid range) */
+  case object NOT_ACCEPTABLE extends AppErrorType(Results.NotAcceptable)
+
   /** Used for any unexpected error */
   case object TECHNICAL extends AppErrorType(Results.InternalServerError)
 

--- a/server/app/io/cumulus/core/validation/AppErrorType.scala
+++ b/server/app/io/cumulus/core/validation/AppErrorType.scala
@@ -13,22 +13,22 @@ sealed abstract class AppErrorType(val status: Results.Status) extends EnumEntry
 object AppErrorType extends Enum[AppErrorType] {
 
   /** Used when a resource is not found */
-  case object NOT_FOUND extends AppErrorType(Results.NotFound)
+  case object NotFound extends AppErrorType(Results.NotFound)
 
   /** Used when the user should be logged in */
-  case object UNAUTHORIZED extends AppErrorType(Results.Unauthorized)
+  case object Unauthorized extends AppErrorType(Results.Unauthorized)
 
   /** Used when the user has no sufficient rights */
-  case object FORBIDDEN extends AppErrorType(Results.Forbidden)
+  case object Forbidden extends AppErrorType(Results.Forbidden)
 
   /** Used when the information provided are invalid */
-  case object VALIDATION extends AppErrorType(Results.BadRequest)
+  case object Validation extends AppErrorType(Results.BadRequest)
 
   /** Used when the information provided are not acceptable (i.e. invalid range) */
-  case object NOT_ACCEPTABLE extends AppErrorType(Results.NotAcceptable)
+  case object NotAcceptable extends AppErrorType(Results.NotAcceptable)
 
   /** Used for any unexpected error */
-  case object TECHNICAL extends AppErrorType(Results.InternalServerError)
+  case object Technical extends AppErrorType(Results.InternalServerError)
 
   override val values: immutable.IndexedSeq[AppErrorType] = findValues
 }

--- a/server/app/io/cumulus/persistence/services/UserService.scala
+++ b/server/app/io/cumulus/persistence/services/UserService.scala
@@ -110,6 +110,7 @@ class UserService(
 
       // Also create the root element of its own file-system
       _ <- QueryE.lift(fsNodeStore.create(Directory.create(user.id, "/")))
+
     } yield user
 
   }.commit()

--- a/server/app/io/cumulus/persistence/stores/SharingStore.scala
+++ b/server/app/io/cumulus/persistence/stores/SharingStore.scala
@@ -3,6 +3,7 @@ package io.cumulus.persistence.stores
 import java.time.LocalDateTime
 import java.util.UUID
 
+import akka.util.ByteString
 import anorm._
 import io.cumulus.core.persistence.CumulusDB
 import io.cumulus.core.persistence.anorm.{AnormPKOperations, AnormRepository}
@@ -24,12 +25,12 @@ class SharingStore(
       SqlParser.get[Option[LocalDateTime]]("expiration") ~
       SqlParser.get[UUID]("user_id") ~
       SqlParser.get[UUID]("fsNode_id") ~
-      SqlParser.get[String]("encryptedPrivateKey") ~
-      SqlParser.get[String]("privateKeySalt") ~
-      SqlParser.get[String]("salt1") ~
-      SqlParser.get[String]("iv") ~
-      SqlParser.get[String]("secretCodeHash") ~
-      SqlParser.get[String]("salt2")
+      SqlParser.get[ByteString]("encryptedPrivateKey") ~
+      SqlParser.get[ByteString]("privateKeySalt") ~
+      SqlParser.get[ByteString]("salt1") ~
+      SqlParser.get[ByteString]("iv") ~
+      SqlParser.get[ByteString]("secretCodeHash") ~
+      SqlParser.get[ByteString]("salt2")
     ).map {
       case id ~ reference ~ expiration ~ owner ~ fsNode ~ encryptedPrivateKey ~ privateKeySalt ~ salt1 ~ iv ~ secretCodeHash ~ salt2 =>
         val sharingSecurity = SharingSecurity(

--- a/server/app/io/cumulus/persistence/stores/UserStore.scala
+++ b/server/app/io/cumulus/persistence/stores/UserStore.scala
@@ -3,6 +3,7 @@ package io.cumulus.persistence.stores
 import java.time.LocalDateTime
 import java.util.UUID
 
+import akka.util.ByteString
 import anorm._
 import io.cumulus.core.persistence.CumulusDB
 import io.cumulus.core.persistence.anorm.{AnormPKOperations, AnormRepository}
@@ -22,12 +23,12 @@ class UserStore(
       SqlParser.get[UUID]("id") ~
       SqlParser.get[String]("email") ~
       SqlParser.get[String]("login") ~
-      SqlParser.get[String]("encryptedPrivateKey") ~
-      SqlParser.get[String]("privateKeySalt") ~
-      SqlParser.get[String]("salt1") ~
-      SqlParser.get[String]("iv") ~
-      SqlParser.get[String]("passwordHash") ~
-      SqlParser.get[String]("salt2") ~
+      SqlParser.get[ByteString]("encryptedPrivateKey") ~
+      SqlParser.get[ByteString]("privateKeySalt") ~
+      SqlParser.get[ByteString]("salt1") ~
+      SqlParser.get[ByteString]("iv") ~
+      SqlParser.get[ByteString]("passwordHash") ~
+      SqlParser.get[ByteString]("salt2") ~
       SqlParser.get[LocalDateTime]("creation") ~
       SqlParser.get[Array[String]]("roles")
     ).map {

--- a/server/conf/messages.conf
+++ b/server/conf/messages.conf
@@ -25,6 +25,17 @@ validation {
     invalid-login-or-password = "The provided password and/or login is not valid"
   }
 
+  sharing {
+    invalid-key = "The provided secret key is not valid"
+    expired = "This sharing is expired"
+  }
+
+  range {
+    range-outside-end = "The end of the provided range is outside of the file"
+    range-outside-start = "The start of the provided range is outside of the file"
+    range-negative = "The provided range is negative"
+  }
+
   fs-node {
     unknown-type = "The type ''{0}'' is not a known type of file system element"
     not-directory = "The element at ''{0}'' is not a directory"


### PR DESCRIPTION
- Suppression de warnings
- Suppression de `.get`
- On ne passe plus inutilement pas du `base64` dans le model, même si on le garde encore en base
- Check supplémentaires pour le range du streaming