### PR TITLE
Metadata extractor (image + PDF)

### DIFF
--- a/server/app/CumulusLoader.scala
+++ b/server/app/CumulusLoader.scala
@@ -56,6 +56,11 @@ class CumulusComponents(
     DeflateStage.name -> DeflateStage
   ))
 
+  implicit val metadataExtractors = MetadataExtractors(Seq(
+    ImageMetadataExtractor,
+    PDFDocumentMetadataExtractor
+  ))
+
   lazy val router: Router = new Routes(
     httpErrorHandler,
     homeController,

--- a/server/app/io/cumulus/core/persistence/query/QueryE.scala
+++ b/server/app/io/cumulus/core/persistence/query/QueryE.scala
@@ -67,7 +67,7 @@ object QueryE {
   def lift[DB <: Database, A](query: Query[DB, A]): QueryE[DB, A] =
     QueryE(query.map(Right.apply))
 
-  def shouldBeFound[DB <: Database, A](query: Query[DB, Option[A]]): QueryE[DB, A] =
+  def get[DB <: Database, A](query: Query[DB, Option[A]]): QueryE[DB, A] =
     QueryE(query.map(_.toRight(AppError.technical("api-error.internal-server-error"))))
 
   def getOrNotFound[DB <: Database, A](query: Query[DB, Option[A]]): QueryE[DB, A] =

--- a/server/app/io/cumulus/core/stream/storage/StorageObjectWriter.scala
+++ b/server/app/io/cumulus/core/stream/storage/StorageObjectWriter.scala
@@ -61,7 +61,6 @@ class StorageObjectWriter(storageEngine: StorageEngine)(implicit ec: ExecutionCo
             size = state.written,
             storageHash = hash, // By default, assume that the object is written directly
             storageSize = state.written
-            // TODO add cipher and/or compression
           )
         )
 
@@ -126,8 +125,7 @@ object StorageObjectWriter {
         creation = LocalDateTime.now
       )
 
-      // TODO handle failure
-      // TODO add cipher and/or compression
+      // TODO handle failure ?
       val output =  storageEngine.writeObject(storageObject.id)
 
       ObjectWriterState(0, output, storageObject, MessageDigest.getInstance("SHA1"))

--- a/server/app/io/cumulus/models/fs/FileMetadata.scala
+++ b/server/app/io/cumulus/models/fs/FileMetadata.scala
@@ -1,29 +1,102 @@
 package io.cumulus.models.fs
 
-import play.api.libs.json.{Format, Json}
+import java.time.LocalDateTime
+
+import play.api.libs.json._
 
 /**
   * File metadata
-  *
-  * @param size The real size of the file
-  * @param hash The real hash of the file
-  * @param mimeType The mime type
   */
-case class FileMetadata(
-  size: Long,
-  hash: String,
-  mimeType: String
-)
+sealed trait FileMetadata {
+  def values: Map[String, String]
+  def tags: Seq[String]
+}
 
 object FileMetadata {
 
-  def default = new FileMetadata(
-    0,
-    "d41d8cd98f00b204e9800998ecf8427e", // MD5 of an empty string/file
-    "application/octet-stream"
-  )
+  private def formatTypeKey = "metadataType"
 
-  implicit val format: Format[FileMetadata] =
-    Json.format[FileMetadata]
+  implicit def reads: Reads[FileMetadata] = {
+    case jsObject: JsObject =>
+      (jsObject \ formatTypeKey).asOpt[String] match {
+        case Some("DefaultMetadata") =>
+          DefaultMetadata.format.reads(jsObject)
+        case Some("ImageMetadata") =>
+          ImageMetadata.format.reads(jsObject)
+        case Some("PDFDocumentMetadata") =>
+          PDFDocumentMetadata.format.reads(jsObject)
+        case other =>
+          JsError(__ \ "nodeType", JsonValidationError("validation.fs-node.unknown-type", other))
+      }
+    case _ =>
+      JsError("validation.parsing.cannot-parse")
+  }
+
+  implicit def writes: OWrites[FileMetadata] = {
+    case defaultMetadata: DefaultMetadata =>
+      DefaultMetadata.format.writes(defaultMetadata) + (formatTypeKey -> JsString("DefaultMetadata"))
+    case imageMetadata: ImageMetadata =>
+      ImageMetadata.format.writes(imageMetadata) + (formatTypeKey -> JsString("ImageMetadata"))
+    case pdfDocumentMetadata: PDFDocumentMetadata =>
+      PDFDocumentMetadata.format.writes(pdfDocumentMetadata) + (formatTypeKey -> JsString("PDFDocumentMetadata"))
+  }
 
 }
+
+case class DefaultMetadata(
+  values: Map[String, String],
+  tags: Seq[String]
+) extends FileMetadata
+
+object DefaultMetadata {
+
+  def empty: DefaultMetadata = new DefaultMetadata(Map.empty, Seq.empty)
+
+  implicit val format: OFormat[DefaultMetadata] =
+    Json.format[DefaultMetadata]
+
+}
+
+case class ImageMetadata(
+  maker: Option[String],
+  model: Option[String],
+  latitudeRef: Option[String],
+  latitude: Option[String],
+  longitudeRef: Option[String],
+  longitude: Option[String],
+  altitude: Option[String],
+  datetime: Option[LocalDateTime],
+  height: Option[Long],
+  width: Option[Long],
+  values: Map[String, String],
+  tags: Seq[String]
+) extends FileMetadata
+
+object ImageMetadata {
+
+  implicit val format: OFormat[ImageMetadata] =
+    Json.format[ImageMetadata]
+
+}
+
+case class PDFDocumentMetadata(
+  pageCount: Long,
+  title: Option[String],
+  author: Option[String],
+  subject: Option[String],
+  creator: Option[String],
+  producer: Option[String],
+  creationDate: Option[LocalDateTime],
+  modificationDate: Option[LocalDateTime],
+  values: Map[String, String],
+  tags: Seq[String]
+) extends FileMetadata
+
+object PDFDocumentMetadata {
+
+  implicit val format: OFormat[PDFDocumentMetadata] =
+    Json.format[PDFDocumentMetadata]
+
+}
+
+

--- a/server/app/io/cumulus/persistence/services/SharingService.scala
+++ b/server/app/io/cumulus/persistence/services/SharingService.scala
@@ -169,10 +169,10 @@ class SharingService(
       }
 
       // Find the user
-      sharingUser <- QueryE.shouldBeFound(userStore.find(sharing.owner))
+      sharingUser <- QueryE.get(userStore.find(sharing.owner))
 
       // Find the base node shared
-      sharedNode <- QueryE.shouldBeFound(fsNodeStore.find(sharing.fsNode))
+      sharedNode <- QueryE.get(fsNodeStore.find(sharing.fsNode))
 
       // Find the element shared
       node <- {

--- a/server/app/io/cumulus/stages/MetadataStage.scala
+++ b/server/app/io/cumulus/stages/MetadataStage.scala
@@ -1,0 +1,206 @@
+package io.cumulus.stages
+
+import java.time.{LocalDateTime, ZoneId}
+import java.time.format.DateTimeFormatter
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+import scala.util.Try
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.StreamConverters
+import com.sksamuel.scrimage
+import io.cumulus.core.stream.storage.StorageReferenceReader
+import io.cumulus.core.utils.Range
+import io.cumulus.core.validation.AppError
+import io.cumulus.models.Session
+import io.cumulus.models.fs._
+import io.cumulus.persistence.storage.StorageEngine
+import org.apache.pdfbox.pdmodel.PDDocument
+
+
+trait MetadataExtractor {
+
+  def extract(
+    file: File,
+    storageEngine: StorageEngine
+  )(implicit
+    ec: ExecutionContext,
+    materializer: Materializer,
+    ciphers: Ciphers,
+    compressions: Compressions,
+    session: Session
+  ): Either[AppError, FileMetadata]
+
+  def applyOn: Seq[String]
+
+}
+
+object DefaultMetadataExtractor extends MetadataExtractor {
+
+  override def extract(
+    file: File,
+    storageEngine: StorageEngine
+  )(implicit
+    ec: ExecutionContext,
+    materializer: Materializer,
+    ciphers: Ciphers,
+    compressions: Compressions,
+    session: Session
+  ): Either[AppError, DefaultMetadata] = {
+    Right(DefaultMetadata.empty)
+  }
+
+  override def applyOn = Seq()
+
+}
+
+object ImageMetadataExtractor extends MetadataExtractor {
+
+  override def extract(
+    file: File,
+    storageEngine: StorageEngine
+  )(implicit
+    ec: ExecutionContext,
+    materializer: Materializer,
+    ciphers: Ciphers,
+    compressions: Compressions,
+    session: Session
+  ): Either[AppError, ImageMetadata] = {
+    StorageReferenceReader(
+      storageEngine,
+      file,
+      Range(0, Long.MaxValue)
+    ).map { source =>
+
+      val fileInputStream = source.runWith(StreamConverters.asInputStream())
+      val metadata = scrimage.ImageMetadata.fromStream(fileInputStream)
+
+      val make  = metadata.tags.find(_.name == "Make").map(_.value)
+      val model = metadata.tags.find(_.name == "Model").map(_.value)
+
+      val latitudeRef = metadata.tags.find(_.name == "GPS Latitude Ref").map(_.value)
+      val latitude = metadata.tags.find(_.name == "GPS Latitude").map(_.value)
+      val longitudeRef = metadata.tags.find(_.name == "GPS Longitude Ref").map(_.value)
+      val longitude = metadata.tags.find(_.name == "GPS Longitude").map(_.value)
+      val altitude = metadata.tags.find(_.name == "GPS Altitude").map(_.value)
+
+      val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss")
+      val datetime = metadata.tags.find(_.name == "Date/Time Original").map(t => LocalDateTime.parse(t.value, dateTimeFormatter))
+
+      val pattern = "(\\d+).*".r
+      val height = metadata.tags.find(_.name == "Image Height").flatMap { t =>
+        t.value match {
+          case pattern(heightValue) =>
+            Try(heightValue.toLong).toOption
+          case _ =>
+            None
+        }
+      }
+      val width = metadata.tags.find(_.name == "Image Width").flatMap { t =>
+        t.value match {
+          case pattern(widthValue) =>
+            Try(widthValue.toLong).toOption
+          case _ =>
+            None
+        }
+      }
+
+      ImageMetadata.apply(
+        maker = make,
+        model = model,
+        latitudeRef = latitudeRef,
+        latitude = latitude,
+        longitudeRef = longitudeRef,
+        longitude = longitude,
+        altitude = altitude,
+        datetime = datetime,
+        height = height,
+        width = width,
+        values = Map(metadata.tags.map(t => t.name -> t.value):_*),
+        tags = Seq.empty
+      )
+    }
+  }
+
+  override def applyOn = Seq(
+    "image/bmp",
+    "image/gif",
+    "image/x-icon",
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/tiff"
+  )
+
+}
+
+object PDFDocumentMetadataExtractor extends MetadataExtractor {
+
+  override def extract(
+    file: File,
+    storageEngine: StorageEngine
+  )(implicit
+    ec: ExecutionContext,
+    materializer: Materializer,
+    ciphers: Ciphers,
+    compressions: Compressions,
+    session: Session
+  ): Either[AppError, PDFDocumentMetadata] = {
+    StorageReferenceReader(
+      storageEngine,
+      file,
+      Range(0, Long.MaxValue)
+    ).map { source =>
+
+      val fileInputStream = source.runWith(StreamConverters.asInputStream())
+      val document = PDDocument.load(fileInputStream)
+
+      val info = document.getDocumentInformation
+      val pageCount: Long = Option(document.getNumberOfPages).map(_.toLong).getOrElse(0)
+      val title = Option(info.getTitle)
+      val author = Option(info.getAuthor)
+      val subject = Option(info.getSubject)
+      val tags = Option(info.getKeywords).map(_.split(";").toSeq.filterNot(_.trim.isEmpty)).getOrElse(Seq[String]())
+      val creator = Option(info.getCreator)
+      val producer = Option(info.getProducer)
+      val creation = Option(info.getCreationDate).map(t => t.toInstant.atZone(ZoneId.systemDefault()).toLocalDateTime)
+      val modification = Option(info.getModificationDate).map(t => t.toInstant.atZone(ZoneId.systemDefault()).toLocalDateTime)
+
+      val keys = info.getMetadataKeys.asScala
+      val values = Map(keys.map(key => Option(info.getCustomMetadataValue(key)).map(v => key -> v)).toSeq.flatten: _*)
+
+      PDFDocumentMetadata(
+        pageCount = pageCount,
+        title = title,
+        author = author,
+        subject = subject,
+        tags = tags,
+        creator = creator,
+        producer = producer,
+        creationDate = creation,
+        modificationDate = modification,
+        values = values
+      )
+    }
+  }
+
+  override def applyOn = Seq(
+    "application/pdf"
+  )
+
+}
+
+case class MetadataExtractors(extractors: Seq[MetadataExtractor]) {
+
+  def get(name: String): MetadataExtractor =
+    extractors
+      .find(_.applyOn.contains(name))
+      .getOrElse(DefaultMetadataExtractor)
+
+  def get(name: Option[String]): MetadataExtractor =
+    name match {
+      case Some(n) => get(n)
+      case _       => DefaultMetadataExtractor
+    }
+
+}

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -60,6 +60,8 @@ lazy val cumulusServer = project
       // Thumbnails generation
       Dependencies.scrimage.core,
       Dependencies.scrimage.ioExtra,
+      // PDF handling
+      Dependencies.pdfbox.core,
       // Crypto
       Dependencies.bouncyCastle.core,
       // Test dependencies

--- a/server/conf/messages.conf
+++ b/server/conf/messages.conf
@@ -36,6 +36,10 @@ validation {
     range-negative = "The provided range is negative"
   }
 
+  metadata {
+    unknown-type = "Unknown type of metadata to parse"
+  }
+
   fs-node {
     unknown-type = "The type ''{0}'' is not a known type of file system element"
     not-directory = "The element at ''{0}'' is not a directory"

--- a/server/conf/messages.fr.conf
+++ b/server/conf/messages.fr.conf
@@ -11,6 +11,14 @@ api-error {
   internal-server-error = "Erreur interne pendant la gestion de la requête"
 }
 
+validation {
+
+  metadata {
+    unknown-type = "Type de métadonnées inconnu"
+  }
+
+}
+
 ui {
   appName = "Cumulus"
   empty = "Vide"

--- a/server/project/Dependencies.scala
+++ b/server/project/Dependencies.scala
@@ -82,4 +82,10 @@ object Dependencies {
     val ioExtra = "com.sksamuel.scrimage" % "scrimage-io-extra_2.12" % version
   }
 
+  object pdfbox {
+    val version = "2.0.8"
+
+    val core = "org.apache.pdfbox" % "pdfbox" % version
+  }
+
 }


### PR DESCRIPTION
Extracteur des métadonnées pour les images (bmp/jpg/gif/png) et le PDF. Les métadonnées sont ajoutées dans un champ `metadata` dans les `File`

Faire référence à #60 