### PR TITLE
Directory sharing update

### DIFF
--- a/server/app/CumulusLoader.scala
+++ b/server/app/CumulusLoader.scala
@@ -122,7 +122,7 @@ class CumulusComponents(
   lazy val homeController: HomeController       = new HomeController(controllerComponents)
   lazy val userController: UserController       = new UserController(controllerComponents, userService)
   lazy val fsController: FileSystemController   = new FileSystemController(controllerComponents, fsNodeService, storageService, sharingService)
-  lazy val sharingController: SharingController = new SharingController(controllerComponents, sharingService, storageService, storageEngine)
+  lazy val sharingController: SharingController = new SharingController(controllerComponents, sharingService, storageService)
   lazy val assetController: Assets              = new Assets(context.environment, assetsMetadata, httpErrorHandler, jsMessageFactory.all, controllerComponents)
 
 }

--- a/server/app/io/cumulus/controllers/FileSystemController.scala
+++ b/server/app/io/cumulus/controllers/FileSystemController.scala
@@ -134,6 +134,8 @@ class FileSystemController(
               Left(e)
           }
         }
+      case FsOperationShareDelete(reference) =>
+        ApiResponse(sharingService.deleteSharing(reference))
       case FsOperationDelete(_) =>
         ApiResponse(fsNodeService.deleteNode(path))
     }

--- a/server/app/io/cumulus/controllers/payloads/fs/FsOperation.scala
+++ b/server/app/io/cumulus/controllers/payloads/fs/FsOperation.scala
@@ -21,6 +21,8 @@ object FsOperation {
           FsOperationMove.format.reads(jsObject)
         case Some(FsOperationType.SHARE_LINK) =>
           FsOperationShareLink.format.reads(jsObject)
+        case Some(FsOperationType.SHARE_DELETE) =>
+          FsOperationShareDelete.format.reads(jsObject)
         case Some(FsOperationType.DELETE) =>
           FsOperationDelete.format.reads(jsObject)
         case other =>
@@ -37,6 +39,8 @@ object FsOperation {
       FsOperationMove.format.writes(fsOperationMove)
     case fsOperationShareLink: FsOperationShareLink =>
       FsOperationShareLink.format.writes(fsOperationShareLink)
+    case fsOperationShareLink: FsOperationShareDelete =>
+      FsOperationShareDelete.format.writes(fsOperationShareLink)
     case fsOperationDelete: FsOperationDelete =>
       FsOperationDelete.format.writes(fsOperationDelete)
   }
@@ -82,6 +86,19 @@ object FsOperationShareLink {
 
   implicit val format: OFormat[FsOperationShareLink] =
     Json.format[FsOperationShareLink]
+
+}
+
+case class FsOperationShareDelete(
+  reference: String
+) extends FsOperation {
+  def operationType: FsOperationType = FsOperationType.SHARE_DELETE
+}
+
+object FsOperationShareDelete {
+
+  implicit val format: OFormat[FsOperationShareDelete] =
+    Json.format[FsOperationShareDelete]
 
 }
 

--- a/server/app/io/cumulus/controllers/payloads/fs/FsOperationType.scala
+++ b/server/app/io/cumulus/controllers/payloads/fs/FsOperationType.scala
@@ -8,10 +8,11 @@ sealed abstract class FsOperationType extends EnumEntry
 
 object FsOperationType extends Enum[FsOperationType] with PlayJsonEnum[FsOperationType] {
 
-  case object CREATE     extends FsOperationType
-  case object MOVE       extends FsOperationType
-  case object SHARE_LINK extends FsOperationType
-  case object DELETE     extends FsOperationType
+  case object CREATE       extends FsOperationType
+  case object MOVE         extends FsOperationType
+  case object SHARE_LINK   extends FsOperationType
+  case object SHARE_DELETE extends FsOperationType
+  case object DELETE       extends FsOperationType
 
   override val values: immutable.IndexedSeq[FsOperationType] = findValues
 

--- a/server/app/io/cumulus/models/Path.scala
+++ b/server/app/io/cumulus/models/Path.scala
@@ -87,6 +87,18 @@ case class Path(value: Seq[String]) {
   def isParentOf(path: Path): Boolean =
     path.value.startsWith(this.value)
 
+  /**
+    * /a/b/c /a/b
+    * @param path
+    * @return
+    */
+  def relativeTo(path: Path): Path = {
+    if(path.isParentOf(this))
+      Path(this.value.drop(path.value.size))
+    else
+      this
+  }
+
   override def toString: String =
     convertPathToStr(this)
 

--- a/server/app/io/cumulus/persistence/services/SharingService.scala
+++ b/server/app/io/cumulus/persistence/services/SharingService.scala
@@ -22,7 +22,14 @@ class SharingService(
   qb: QueryBuilder[CumulusDB]
 ) extends Logging {
 
-  // TODO doc
+  /**
+    * Share a node.
+    *
+    * @param path The path of the node to be shared
+    * @param password The password of the user performing the sharing
+    * @param expiration Optional date of expiration of the sharing
+    * @param user The user performing the operation
+    */
   def shareNode(
     path: Path,
     password: String,
@@ -56,7 +63,31 @@ class SharingService(
 
   }.commit()
 
-  // TODO doc
+  /**
+    * List of the sharings of the node.
+    *
+    * @param path The path of the node
+    * @param user The user performing the operation
+    */
+  def list(path: Path)(implicit user: User): Future[Either[AppError, Seq[Sharing]]] = {
+
+    for {
+      // Find the node
+      node <- QueryE.getOrNotFound(fsNodeStore.findByPathAndUser(path, user))
+
+      // Find all the sharing of this node
+      sharings <- QueryE.lift(sharingStore.findByNode(node))
+
+    } yield sharings
+
+  }.commit()
+
+  /**
+    * Delete a sharing.
+    *
+    * @param reference The reference of the sharing to delete
+    * @param user The user performing the operation
+    */
   def deleteSharing(
     reference: String
   )(implicit user: User): Future[Either[AppError, Unit]] = {
@@ -67,7 +98,7 @@ class SharingService(
 
       _ <- QueryE.pure {
         if(sharing.owner != user.id)
-          Left(AppError.forbidden("")) // TODO
+          Left(AppError.forbidden("validation.sharing.forbidden"))
         else
           Right(())
       }
@@ -79,7 +110,12 @@ class SharingService(
 
   }.commit()
 
-  // TODO doc
+
+  /**
+    * Returns a shared directory. Will fail if the element is not a directory or not found.
+    *
+    * @see [[io.cumulus.persistence.services.SharingService#findSharedNode SharingService.findSharedNode]]
+    */
   def findSharedDirectory(
     reference: String,
     path: Path,
@@ -104,7 +140,11 @@ class SharingService(
 
   }.commit()
 
-  // TODO doc
+  /**
+    * Returns a shared file. Will fail if the element is not a file or not found.
+    *
+    * @see [[io.cumulus.persistence.services.SharingService#findSharedNode SharingService.findSharedNode]]
+    */
   def findSharedFile(
     reference: String,
     path: Path,
@@ -129,7 +169,13 @@ class SharingService(
 
   }.commit()
 
-  // TODO doc
+  /**
+    * Finds and returns a shared node.
+    *
+    * @param reference The reference of the shared node
+    * @param path The path of the element, relative to the shared node
+    * @param secretCode The secret code of the sharing
+    */
   def findSharedNode(
     reference: String,
     path: Path,
@@ -137,7 +183,15 @@ class SharingService(
   ): Future[Either[AppError, (Sharing, User, FsNode)]] =
     find(reference, path, secretCode).commit()
 
-  // TODO doc
+  /**
+    * Finds a shared node by its reference, relative path and secret code. For example, if the directory `/foo/bar`
+    * is shared and the find method is call this sharing with the path `/fuzz`, then the element `/foo/bar/fuzz` will
+    * be searched (and returned if found). The returned node will have a sanitized path relative to the shared node.
+    *
+    * @param reference The reference of the sharing
+    * @param path The path of the element contained. Use `/` to get the base shared element (directory or file)
+    * @param secretCode The secret code of the sharing
+    */
   private def find(
     reference: String,
     path: Path,
@@ -179,12 +233,15 @@ class SharingService(
         if(path.isRoot)
           QueryE.pure(sharedNode)
         else {
-          val realPath: Path = sharedNode.path + "/" + path
+          val realPath: Path = sharedNode.path ++ path
           QueryE.getOrNotFound(fsNodeStore.findByPathAndUser(realPath, sharingUser))
         }
       }
 
-    } yield (sharing, sharingUser, node)
+      // Do not expose the real path
+      sanitizedNode = node.moved(path.relativeTo(sharedNode.path))
+
+    } yield (sharing, sharingUser, sanitizedNode)
 
   }
 

--- a/server/app/io/cumulus/persistence/stores/SharingStore.scala
+++ b/server/app/io/cumulus/persistence/stores/SharingStore.scala
@@ -20,7 +20,36 @@ class SharingStore(
   val pkField: String = SharingStore.pkField
 
   /**
-    * Find the sharing for a provided node.
+    * Find the sharings for a provided node.
+    * @param fsNode The shared node
+    */
+  def findByNode(fsNode: FsNode): Query[CumulusDB, List[Sharing]] =
+    qb { implicit c =>
+
+      val idField = s"${FsNodeStore.table}.${FsNodeStore.pkField}"
+
+      SQL"""
+          SELECT
+            #$table.#$pkField,
+            #$table.reference,
+            #$table.expiration,
+            #$table.user_id,
+            #$table.fsNode_id,
+            #$table.encryptedPrivateKey,
+            #$table.privateKeySalt,
+            #$table.salt1,
+            #$table.iv,
+            #$table.secretCodeHash,
+            #$table.salt2
+            FROM #$table
+          INNER JOIN #${FsNodeStore.table}
+          ON #$table.fsNode_id = #${FsNodeStore.table}.id
+          WHERE #$idField = ${fsNode.id}
+        """.as(rowParser.*)
+    }
+
+  /**
+    * Find and lock the sharings for a provided node.
     * @param fsNode The shared node
     */
   def findAndLockByNode(fsNode: FsNode): Query[CumulusDB, List[Sharing]] =

--- a/server/conf/messages.conf
+++ b/server/conf/messages.conf
@@ -27,6 +27,7 @@ validation {
 
   sharing {
     invalid-key = "The provided secret key is not valid"
+    forbidden = "You are not allowed to edit this sharing"
     expired = "This sharing is expired"
   }
 

--- a/server/conf/messages.fr.conf
+++ b/server/conf/messages.fr.conf
@@ -27,6 +27,7 @@ validation {
 
   sharing {
     invalid-key = "The provided secret key is not valid"
+    forbidden = "Vous n''êtes pas autorisé à modifier ce partage"
     expired = "This sharing is expired"
   }
 

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -13,6 +13,7 @@ GET     /api/fs*path                  io.cumulus.controllers.FileSystemControlle
 PUT     /api/fs*path                  io.cumulus.controllers.FileSystemController.create(path: Path)
 POST    /api/fs*path                  io.cumulus.controllers.FileSystemController.update(path: Path)
 DELETE  /api/fs*path                  io.cumulus.controllers.FileSystemController.delete(path: Path)
+GET     /api/sharings/fs*path         io.cumulus.controllers.SharingController.list(path: Path)
 
 # API- Search
 GET     /api/search*path              io.cumulus.controllers.FileSystemController.search(path: Path, name: String, nodeType: Option[FsNodeType], `type`: Option[String])


### PR DESCRIPTION
- Ajoute une route pour récupérer les sharings d'un fichier/dossier
- Empêche de donner le chemin réel des ressources partagées contenues dans des dossiers.
- Ajoute une route pour supprimer des sharings