### PR TITLE
Fix upload + Change upload error handling

### DIFF
--- a/server/src/main/resources/messages.conf
+++ b/server/src/main/resources/messages.conf
@@ -38,7 +38,14 @@ validation {
   }
 
   metadata {
+    failed = "Metadata parsing failed with the following error: {0}"
+    failed-no-message = "Metadata parsing failed without an error message"
     unknown-type = "Unknown type of metadata to parse"
+  }
+
+  thumbnail {
+    failed = "Thumbnail generation failed with the following error: {0}"
+    failed-no-message = "Thumbnail generation failed without an error message"
   }
 
   fs-node {

--- a/server/src/main/resources/messages.fr.conf
+++ b/server/src/main/resources/messages.fr.conf
@@ -38,7 +38,14 @@ validation {
   }
 
   metadata {
+    failed = "La lecture des métadonnées a échoué avec l''erreur suivante : {0}"
+    failed-no-message = "La lecture des métadonnées a échoué sans message d''erreur"
     unknown-type = "Type de métadonnées inconnu"
+  }
+
+  thumbnail {
+    failed = "La génération de l'aperçu a échoué avec l''erreur suivante : {0}"
+    failed-no-message = "La génération de l'aperçu a échoué sans message d''erreur"
   }
 
   fs-node {

--- a/server/src/main/scala/io/cumulus/controllers/FileSystemController.scala
+++ b/server/src/main/scala/io/cumulus/controllers/FileSystemController.scala
@@ -2,7 +2,7 @@ package io.cumulus.controllers
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import cats.data.EitherT
 import cats.implicits._
@@ -140,32 +140,7 @@ class FileSystemController(
   def upload(path: Path, cipherName: Option[String], compressionName: Option[String]): Action[Source[ByteString, _]] =
     AuthenticatedAction.async(streamBody) { implicit request =>
       ApiResponse {
-        /*
-        val modifications = for {
-          // Get the cipher and compression from the request
-          cipher <- EitherT.fromEither[Future](ciphers.get(cipherName))
-          compression <- EitherT.fromEither[Future](compressions.get(compressionName))
-        } yield cipher -> compression
-
-        modifications
-          .flatMap { case (cipher, compression) =>
-            EitherT(storageService.uploadFile(path, cipher, compression, request.body))
-          }
-          .leftMap { error =>
-            request.body.runWith(Sink.ignore)
-            error
-          }
-        */
-
-        for {
-          // Get the cipher and compression from the request
-          cipher      <- EitherT.fromEither[Future](ciphers.get(cipherName))
-          compression <- EitherT.fromEither[Future](compressions.get(compressionName))
-
-          // Upload & create the file
-          file <- EitherT(storageService.uploadFile(path, cipher, compression, request.body))
-
-        } yield file
+        storageService.uploadFile(path, cipherName, compressionName, request.body)
       }
     }
 

--- a/server/src/main/scala/io/cumulus/controllers/FileSystemController.scala
+++ b/server/src/main/scala/io/cumulus/controllers/FileSystemController.scala
@@ -2,7 +2,7 @@ package io.cumulus.controllers
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import cats.data.EitherT
 import cats.implicits._
@@ -140,6 +140,23 @@ class FileSystemController(
   def upload(path: Path, cipherName: Option[String], compressionName: Option[String]): Action[Source[ByteString, _]] =
     AuthenticatedAction.async(streamBody) { implicit request =>
       ApiResponse {
+        /*
+        val modifications = for {
+          // Get the cipher and compression from the request
+          cipher <- EitherT.fromEither[Future](ciphers.get(cipherName))
+          compression <- EitherT.fromEither[Future](compressions.get(compressionName))
+        } yield cipher -> compression
+
+        modifications
+          .flatMap { case (cipher, compression) =>
+            EitherT(storageService.uploadFile(path, cipher, compression, request.body))
+          }
+          .leftMap { error =>
+            request.body.runWith(Sink.ignore)
+            error
+          }
+        */
+
         for {
           // Get the cipher and compression from the request
           cipher      <- EitherT.fromEither[Future](ciphers.get(cipherName))

--- a/server/src/main/scala/io/cumulus/persistence/services/FsNodeService.scala
+++ b/server/src/main/scala/io/cumulus/persistence/services/FsNodeService.scala
@@ -300,9 +300,9 @@ class FsNodeService(
         case Some(_: Directory) =>
           Left(AppError.validation(__ \ "path", "validation.fs-node.directory-already-exists", path))
         case Some(_: File) =>
-          Left(AppError.validation(__ \ "path", "validation.fs-node.file-already-exists", path))
+          Left(AppError.validation("validation.fs-node.file-already-exists", path))
         case Some(_) =>
-          Left(AppError.validation(__ \ "path", "validation.fs-node.node-already-exists", path))
+          Left(AppError.validation("validation.fs-node.node-already-exists", path))
         case None =>
           Right(())
       }


### PR DESCRIPTION
Change l'upload pour fonctionner correctement sur navigateur même en cas d'erreur.
Change la gestion d'erreur de la génération des miniatures et de la génération des métadonnées pour ignorer et simplement logger les erreurs.