### PR TITLE
Private key per file

### DIFF
--- a/server/src/main/resources/evolutions/default/1.sql
+++ b/server/src/main/resources/evolutions/default/1.sql
@@ -1,6 +1,6 @@
 # --- !Ups
 
--- Users
+  -- Users
   CREATE TABLE cumulus_user (
     id                  UUID          PRIMARY KEY,
     email               VARCHAR(255)  NOT NULL,
@@ -18,7 +18,7 @@
   CREATE UNIQUE INDEX user_mail_unique ON cumulus_user (LOWER(email));
   CREATE UNIQUE INDEX user_login_unique ON cumulus_user (LOWER(login));
 
--- File system
+  -- File system
   CREATE TABLE fs_node (
     id           UUID      PRIMARY KEY,
     path         TEXT      NOT NULL,
@@ -38,15 +38,9 @@
   CREATE TABLE sharing (
     id                  UUID          PRIMARY KEY,
     reference           VARCHAR(64)   NOT NULL,
-    expiration          TIMESTAMP             ,
     user_id             UUID          REFERENCES cumulus_user(id), -- Owner
     fsNode_id           UUID          REFERENCES fs_node(id),      -- Node shared
-    encryptedPrivateKey VARCHAR(64)   NOT NULL,
-    privateKeySalt      VARCHAR(64)   NOT NULL,
-    salt1               VARCHAR(64)   NOT NULL,
-    iv                  VARCHAR(64)   NOT NULL,
-    secretCodeHash      VARCHAR(64)   NOT NULL,
-    salt2               VARCHAR(64)   NOT NULL
+    metadata            JSONB         NOT NULL                     -- Contains metadata about the sharing
   );
 
   CREATE UNIQUE INDEX sharing_reference_unique ON sharing (reference);

--- a/server/src/main/resources/messages.conf
+++ b/server/src/main/resources/messages.conf
@@ -26,6 +26,7 @@ validation {
   }
 
   sharing {
+    invalid-type = "This type of node cannot be shared"
     invalid-key = "The provided secret key is not valid"
     forbidden = "You are not allowed to edit this sharing"
     expired = "This sharing is expired"
@@ -62,8 +63,9 @@ validation {
     no-parent = "The parent ''{0}'' of the created element does not exist"
     non-empty = "The directory ''{0}'' is not empty. Only empty directories can be deleted"
     unknown-cipher = "The cipher ''{0}'' is not a valid cipher name"
+    unknown-key = "The file ''{0}'' does not have an encryption key within this sharing; decryption impossible"
     unknown-compression = "The compresson ''{0}'' is not a valid compresson name"
-    unknown-storage-engie = "The storage engine ''{0}'' is not a valid storage angine"
+    unknown-storage-engine = "The storage engine ''{0}'' is not a valid storage angine"
     no-thumbnail = "The file ''{0}'' does not have a thumbnail"
     no-storage-reference = "The file does not have any storage reference and can''t be downloaded"
   }

--- a/server/src/main/resources/messages.fr.conf
+++ b/server/src/main/resources/messages.fr.conf
@@ -26,6 +26,7 @@ validation {
   }
 
   sharing {
+    invalid-type = "Ce type d''élément ne peut pas être partagé"
     invalid-key = "The provided secret key is not valid"
     forbidden = "Vous n''êtes pas autorisé à modifier ce partage"
     expired = "This sharing is expired"
@@ -62,8 +63,9 @@ validation {
     no-parent = "The parent ''{0}'' of the created element does not exist"
     non-empty = "The directory ''{0}'' is not empty. Only empty directories can be deleted"
     unknown-cipher = "Le type de chiffrement ''{0}'' n''est pas un type de chiffrement valide"
+    unknown-key = "Le fichier ''{0}'' ne possède pas de clef de chiffrement avec ce partage; déchiffrement impossible"
     unknown-compression = "Le type de compresson ''{0}'' n''est pas un type de compression valide"
-    unknown-storage-engie = "Le moteur de stockage ''{0}'' n'est pas un moteur de stockage valide"
+    unknown-storage-engine = "Le moteur de stockage ''{0}'' n'est pas un moteur de stockage valide"
     no-thumbnail = "Le fichier ''{0}'' ne possède pas de miniature"
     no-storage-reference = "Le fichier ne possède pas de référence de stockage et ne peut être téléchargé"
   }

--- a/server/src/main/scala/io/cumulus/CumulusRecoveryServer.scala
+++ b/server/src/main/scala/io/cumulus/CumulusRecoveryServer.scala
@@ -1,5 +1,6 @@
 package io.cumulus
 
+import java.security.Security
 import scala.concurrent.ExecutionContextExecutor
 
 import _root_.controllers.AssetsComponents
@@ -10,6 +11,7 @@ import io.cumulus.controllers.RecoveryController
 import io.cumulus.controllers.utils.{Assets, LoggingFilter}
 import io.cumulus.core.controllers.utils.api.{ApiUtils, HttpErrorHandler}
 import jsmessages.{JsMessages, JsMessagesFactory}
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import play.api
 import play.api.i18n.MessagesApi
 import play.api.mvc.EssentialFilter
@@ -43,6 +45,10 @@ class CumulusRecoveryComponents(
   with AssetsComponents
   with ApiUtils {
 
+  // Security provider
+  Security.addProvider(new BouncyCastleProvider)
+
+  // Routes
   lazy val router = Router.from {
     case GET(p"/api/admin/management/reload") =>
       controller.reload

--- a/server/src/main/scala/io/cumulus/CumulusServer.scala
+++ b/server/src/main/scala/io/cumulus/CumulusServer.scala
@@ -1,5 +1,6 @@
 package io.cumulus
 
+import java.security.Security
 import scala.concurrent.ExecutionContextExecutor
 
 import _root_.controllers.AssetsComponents
@@ -20,6 +21,7 @@ import io.cumulus.persistence.storage.{ChunkRemover, StorageEngines}
 import io.cumulus.persistence.stores.{FsNodeStore, SharingStore, UserStore}
 import io.cumulus.stages._
 import jsmessages.{JsMessages, JsMessagesFactory}
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import play.api._
 import play.api.db.evolutions.EvolutionsComponents
 import play.api.db.{DBComponents, Database, HikariCPComponents}
@@ -92,6 +94,9 @@ class CumulusComponents(
   implicit val storageEngines = StorageEngines(Seq(
     LocalStorage
   ))
+
+  // Security provider
+  Security.addProvider(new BouncyCastleProvider)
 
   // Compile time generated router
   val routerPrefix: String = "/"

--- a/server/src/main/scala/io/cumulus/controllers/FileSystemController.scala
+++ b/server/src/main/scala/io/cumulus/controllers/FileSystemController.scala
@@ -31,8 +31,6 @@ class FileSystemController(
   sharingService: SharingService
 )(implicit
   ec: ExecutionContext,
-  ciphers: Ciphers,
-  compressions: Compressions,
   settings: Settings
 ) extends AbstractController(cc) with Authentication[UserSession] with ApiUtils with FileDownloaderUtils with BodyParserJson with BodyParserStream {
 
@@ -173,7 +171,7 @@ class FileSystemController(
           ApiResponse(fsNodeService.moveNode(path, to))
         case FsOperationShareLink(_, duration, _) =>
           ApiResponse {
-            sharingService.shareNode(path, request.user.password, duration).map {
+            sharingService.shareNode(path, duration).map {
               case Right((sharing, secretCode)) =>
                 Right(Json.toJsObject(sharing)(Sharing.apiWrite)
                   + ("key" -> Json.toJson(secretCode))

--- a/server/src/main/scala/io/cumulus/core/json/JsonFormat.scala
+++ b/server/src/main/scala/io/cumulus/core/json/JsonFormat.scala
@@ -13,7 +13,7 @@ object JsonFormat {
   /**
     * UUID JSON format.
     */
-  implicit val UUIDFormat: Format[UUID] = new Format[UUID] {
+  implicit val uuidFormat: Format[UUID] = new Format[UUID] {
 
     override def reads(json: JsValue): JsResult[UUID] =
       Json.fromJson[String](json).flatMap { s =>
@@ -25,6 +25,20 @@ object JsonFormat {
 
     override def writes(o: UUID): JsValue =
       JsString(o.toString)
+
+  }
+
+  implicit def uuidMapFormat[V](implicit format: Format[V]): Format[Map[UUID, V]] = new Format[Map[UUID, V]] {
+
+    override def reads(json: JsValue): JsResult[Map[UUID, V]] =
+      JsSuccess(json.as[Map[String, V]].map { case (k, v) =>
+        UUID.fromString(k) -> v
+      })
+
+    override def writes(o: Map[UUID, V]): JsValue = {
+      val writer = implicitly[Writes[Map[String, V]]]
+      writer.writes(o.map { case (k, v) => k.toString -> v })
+    }
 
   }
 

--- a/server/src/main/scala/io/cumulus/core/stream/storage/StorageReferenceReader.scala
+++ b/server/src/main/scala/io/cumulus/core/stream/storage/StorageReferenceReader.scala
@@ -159,7 +159,7 @@ object StorageReferenceReader extends Logging {
   private def transformationForThumbnail(file: File)(implicit session: Session, ciphers: Ciphers, compressions: Compressions) = {
     file.thumbnailStorageReference.map { storageReference =>
       for {
-        cipher      <- cipherStageFoStorageReference(storageReference)
+        cipher      <- cipherStageForStorageReference(storageReference)
         compression <- compressionStageForStorageReference(storageReference)
       } yield {
         Flow[ByteString]
@@ -172,7 +172,7 @@ object StorageReferenceReader extends Logging {
   /** Generate the transformations for a given file. */
   private def transformationForFile(file: File)(implicit session: Session, ciphers: Ciphers, compressions: Compressions) = {
     for {
-      cipher      <- cipherStageFoStorageReference(file.storageReference)
+      cipher      <- cipherStageForStorageReference(file.storageReference)
       compression <- compressionStageForStorageReference(file.storageReference)
     } yield {
       Flow[ByteString]
@@ -182,7 +182,7 @@ object StorageReferenceReader extends Logging {
   }
 
   /** Generate the decryption stage for a given file. */
-  private def cipherStageFoStorageReference(storageReference: StorageReference)(implicit session: Session, ciphers: Ciphers) =
+  private def cipherStageForStorageReference(storageReference: StorageReference)(implicit session: Session, ciphers: Ciphers) =
     storageReference.cipher match {
       case None =>
         Right(None)

--- a/server/src/main/scala/io/cumulus/core/stream/storage/StorageReferenceReader.scala
+++ b/server/src/main/scala/io/cumulus/core/stream/storage/StorageReferenceReader.scala
@@ -11,7 +11,7 @@ import io.cumulus.core.utils.Range
 import io.cumulus.core.validation.AppError
 import io.cumulus.models.Session
 import io.cumulus.models.fs.File
-import io.cumulus.persistence.storage.{StorageEngines, StorageObject}
+import io.cumulus.persistence.storage.{StorageCipher, StorageEngines, StorageObject, StorageReference}
 import io.cumulus.stages.{Ciphers, Compressions}
 
 object StorageReferenceReader extends Logging {
@@ -31,7 +31,7 @@ object StorageReferenceReader extends Logging {
     ec: ExecutionContext
   ): Either[AppError, Source[ByteString, NotUsed]] =
     for {
-      transformation   <- transformationForFile(file)
+      transformation   <- transformationForThumbnail(file)
       storageReference <- file.thumbnailStorageReference.toRight(AppError.notFound("validation.fs-node.no-thumbnail", file.name))
       storageEngine    <- storageEngines.get(storageReference)
       source = {
@@ -156,17 +156,49 @@ object StorageReferenceReader extends Logging {
   }
 
   /** Generate the transformations for a given file. */
-  private def transformationForFile(file: File)(implicit session: Session, ciphers: Ciphers, compressions: Compressions) =
-    for {
-      cipher      <- ciphers.get(file.storageReference.cipher)
-      compression <- compressions.get(file.storageReference.compression)
-    } yield {
-      val (privateKey, salt) = session.privateKeyAndSalt
+  private def transformationForThumbnail(file: File)(implicit session: Session, ciphers: Ciphers, compressions: Compressions) = {
+    file.thumbnailStorageReference.map { storageReference =>
+      for {
+        cipher      <- cipherStageFoStorageReference(storageReference)
+        compression <- compressionStageForStorageReference(storageReference)
+      } yield {
+        Flow[ByteString]
+          .via(cipher.getOrElse(Flow[ByteString]))
+          .via(compression.getOrElse(Flow[ByteString]))
+      }
+    }.getOrElse(Right(Flow[ByteString]))
+  }
 
+  /** Generate the transformations for a given file. */
+  private def transformationForFile(file: File)(implicit session: Session, ciphers: Ciphers, compressions: Compressions) = {
+    for {
+      cipher      <- cipherStageFoStorageReference(file.storageReference)
+      compression <- compressionStageForStorageReference(file.storageReference)
+    } yield {
       Flow[ByteString]
-        .via(cipher.map(_.decrypt(privateKey, salt)).getOrElse(Flow[ByteString]))
-        .via(compression.map(_.uncompress).getOrElse(Flow[ByteString]))
+        .via(cipher.getOrElse(Flow[ByteString]))
+        .via(compression.getOrElse(Flow[ByteString]))
     }
+  }
+
+  /** Generate the decryption stage for a given file. */
+  private def cipherStageFoStorageReference(storageReference: StorageReference)(implicit session: Session, ciphers: Ciphers) =
+    storageReference.cipher match {
+      case None =>
+        Right(None)
+      case Some(StorageCipher(cipherName, _, salt, _)) =>
+        for {
+          cipher     <- ciphers.get(cipherName)
+          privateKey <- session.privateKeyOfFile(storageReference).toRight(AppError.validation("validation.fs-node.unknown-key", storageReference.id.toString))
+        } yield Some(cipher.decrypt(privateKey, salt))
+
+    }
+
+  /** Generate the decompression stage for a given file. */
+  private def compressionStageForStorageReference(storageReference: StorageReference)(implicit compressions: Compressions) =
+    compressions
+      .get(storageReference.compression)
+      .map(_.map(_.uncompress))
 
   /** Custom error handler to log errors */
   private def errorHandler(file: File): PartialFunction[Throwable, ByteString] = {

--- a/server/src/main/scala/io/cumulus/core/utils/Crypto.scala
+++ b/server/src/main/scala/io/cumulus/core/utils/Crypto.scala
@@ -1,11 +1,10 @@
 package io.cumulus.core.utils
 
 import java.security.SecureRandom
-import java.util.Random
-import javax.crypto.{Cipher, SecretKey}
-import javax.crypto.spec.{IvParameterSpec, SecretKeySpec}
 
 import akka.util.ByteString
+import javax.crypto.spec.{IvParameterSpec, SecretKeySpec}
+import javax.crypto.{Cipher, SecretKey}
 import org.bouncycastle.crypto.generators.SCrypt
 
 object Crypto {
@@ -13,7 +12,7 @@ object Crypto {
   /**
     * @see [[https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html#SecureRandom-- SecureRandom]]
     */
-  implicit val random: SecureRandom = new SecureRandom()
+  private val random: SecureRandom = new SecureRandom()
 
   /**
     * Generate a random code of the required size. The code will contains only alphanumerical symbols.
@@ -76,10 +75,9 @@ object Crypto {
     * Generate a random salt.
     *
     * @param size The size (in number of bytes)
-    * @param random The random to use (default is [[https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html#SecureRandom-- SecureRandom]])
     * @return The salt
     */
-  def randomBytes(size: Int)(implicit random: Random): ByteString = {
+  def randomBytes(size: Int): ByteString = {
     val bytes = new Array[Byte](size)
     random.nextBytes(bytes)
     ByteString(bytes)

--- a/server/src/main/scala/io/cumulus/models/fs/FsNode.scala
+++ b/server/src/main/scala/io/cumulus/models/fs/FsNode.scala
@@ -235,7 +235,7 @@ object File {
       JsonFormat.humanReadable(file.size),
       file.hash,
       file.mimeType,
-      file.storageReference.cipher,
+      file.storageReference.cipher.map(_.cipher),
       file.storageReference.compression,
       file.metadata,
       file.thumbnailStorageReference.isDefined

--- a/server/src/main/scala/io/cumulus/persistence/services/StorageService.scala
+++ b/server/src/main/scala/io/cumulus/persistence/services/StorageService.scala
@@ -72,16 +72,17 @@ class StorageService(
         content.runWith(Sink.ignore).map(_ => error)
       }
       .flatMap { case (cipher, compression) =>
-        // Define the file writer from this information
-        val fileWriter =
-          StorageReferenceWriter.writer(
-            storageEngines.default, // Always use the default storage engine during upload
-            cipher,
-            compression,
-            path
-          )
-
         for {
+          // Define the file writer from this information
+          fileWriter <- EitherT.fromEither[Future] {
+            StorageReferenceWriter.writer(
+              storageEngines.default, // Always use the default storage engine during upload
+              cipher,
+              compression,
+              path
+            )
+          }
+
           // Store the file's content
           uploadedFile <- EitherT.liftF(content.runWith(fileWriter))
 

--- a/server/src/main/scala/io/cumulus/persistence/stores/FsNodeStore.scala
+++ b/server/src/main/scala/io/cumulus/persistence/stores/FsNodeStore.scala
@@ -95,7 +95,7 @@ class FsNodeStore(
   }
 
   def rowParser: RowParser[FsNode] = {
-    implicit def fsNodeCase: Column[FsNode] = AnormSupport.column[FsNode](FsNode.internalFormat)
+    implicit def fsNodeColumn: Column[FsNode] = AnormSupport.column[FsNode](FsNode.internalFormat)
 
     SqlParser.get[FsNode]("metadata")
   }

--- a/server/src/main/scala/io/cumulus/persistence/stores/SharingStore.scala
+++ b/server/src/main/scala/io/cumulus/persistence/stores/SharingStore.scala
@@ -109,8 +109,8 @@ class SharingStore(
     implicit def fsNodeColumn: Column[FsNode]   = AnormSupport.column[FsNode](FsNode.internalFormat)
 
     (
-      SqlParser.get[Sharing](metadataField) ~
-      SqlParser.get[FsNode](FsNodeStore.metadataField)
+      SqlParser.get[Sharing](s"$table.$metadataField") ~
+      SqlParser.get[FsNode](s"${FsNodeStore.table}.${FsNodeStore.metadataField}")
     ).map {
       case sharing ~ fsNode =>
         SharingInfo(sharing, fsNode)

--- a/server/src/main/scala/io/cumulus/persistence/stores/SharingStore.scala
+++ b/server/src/main/scala/io/cumulus/persistence/stores/SharingStore.scala
@@ -1,9 +1,7 @@
 package io.cumulus.persistence.stores
 
-import java.time.LocalDateTime
 import java.util.UUID
 
-import akka.util.ByteString
 import anorm._
 import io.cumulus.core.persistence.CumulusDB
 import io.cumulus.core.persistence.anorm.AnormSupport._
@@ -33,7 +31,7 @@ class SharingStore(
   def findInfoByUser(user: User, pagination: QueryPagination): Query[CumulusDB, PaginatedList[SharingInfo]] =
     qb { implicit c =>
       SQL"""
-          SELECT #$selectAllWithFsNode
+          SELECT #$table.#$metadataField, #${FsNodeStore.table}.#${FsNodeStore.metadataField}
           FROM #$table
           INNER JOIN #${FsNodeStore.table}
           ON #$table.#$fsNodeField = #${FsNodeStore.table}.#${FsNodeStore.pkField}
@@ -50,7 +48,7 @@ class SharingStore(
   def findInfoByNode(fsNode: FsNode, pagination: QueryPagination): Query[CumulusDB, PaginatedList[SharingInfo]] =
     qb { implicit c =>
       SQL"""
-          SELECT #$selectAllWithFsNode
+          SELECT #$table.#$metadataField, #${FsNodeStore.table}.#${FsNodeStore.metadataField}
           FROM #$table
           INNER JOIN #${FsNodeStore.table}
           ON #$table.#$fsNodeField = #${FsNodeStore.table}.#${FsNodeStore.pkField}
@@ -67,7 +65,7 @@ class SharingStore(
     qb { implicit c =>
 
       SQL"""
-          SELECT #$selectAllWithFsNode
+          SELECT #$table.#$metadataField, #${FsNodeStore.table}.#${FsNodeStore.metadataField}
           FROM #$table
           INNER JOIN #${FsNodeStore.table}
           ON #$table.#$fsNodeField = #${FsNodeStore.table}.#${FsNodeStore.pkField}
@@ -84,7 +82,7 @@ class SharingStore(
     qb { implicit c =>
 
       SQL"""
-          SELECT #$selectAll
+          SELECT #$table.#$metadataField
           FROM #$table
           WHERE #$fsNodeField = ${fsNode.id}
           #${pagination.toLIMIT}
@@ -99,107 +97,39 @@ class SharingStore(
     qb { implicit c =>
 
       SQL"""
-          SELECT #$selectAll
+          SELECT #$table.#$metadataField
           FROM #$table
           WHERE #$fsNodeField = ${fsNode.id}
           FOR UPDATE
         """.as(rowParser.*)
     }
 
-  val selectAll =
-    s"""
-      $table.$pkField,
-      $table.$referenceField,
-      $table.$expirationField,
-      $table.$ownerField,
-      $table.$fsNodeField,
-      $table.$encryptedPrivateKeyField,
-      $table.$privateKeySaltField,
-      $table.$salt1Field,
-      $table.$ivField,
-      $table.$secretCodeHashField,
-      $table.$salt2Field
-    """
-
-  val selectAllWithFsNode =
-    s"""
-      $selectAll,
-      ${FsNodeStore.table}.${FsNodeStore.metadataField}
-    """
-
   val withFsNodeRowParser: RowParser[SharingInfo] = {
-    implicit def fsNodeCase: Column[FsNode] = AnormSupport.column[FsNode](FsNode.internalFormat)
+    implicit def sharingColumn: Column[Sharing] = AnormSupport.column[Sharing](Sharing.internalFormat)
+    implicit def fsNodeColumn: Column[FsNode]   = AnormSupport.column[FsNode](FsNode.internalFormat)
 
-    SqlParser.get[FsNode]("metadata")
     (
-      SqlParser.get[UUID](pkField) ~
-      SqlParser.get[String](referenceField) ~
-      SqlParser.get[Option[LocalDateTime]](expirationField) ~
-      SqlParser.get[UUID](ownerField) ~
-      SqlParser.get[UUID](fsNodeField) ~
-      SqlParser.get[ByteString](encryptedPrivateKeyField) ~
-      SqlParser.get[ByteString](privateKeySaltField) ~
-      SqlParser.get[ByteString](salt1Field) ~
-      SqlParser.get[ByteString](ivField) ~
-      SqlParser.get[ByteString](secretCodeHashField) ~
-      SqlParser.get[ByteString](salt2Field) ~
+      SqlParser.get[Sharing](metadataField) ~
       SqlParser.get[FsNode](FsNodeStore.metadataField)
     ).map {
-      case id ~ reference ~ expiration ~ owner ~ fsNodeUUID ~ encryptedPrivateKey ~ privateKeySalt ~ salt1 ~ iv ~ secretCodeHash ~ salt2 ~ fsNode =>
-        val sharingSecurity = SharingSecurity(
-          encryptedPrivateKey,
-          privateKeySalt,
-          salt1,
-          iv,
-          secretCodeHash,
-          salt2
-        )
-
-        SharingInfo(Sharing(id, reference, expiration, owner, fsNodeUUID, sharingSecurity), fsNode)
+      case sharing ~ fsNode =>
+        SharingInfo(sharing, fsNode)
     }
   }
 
   val rowParser: RowParser[Sharing] = {
-    (
-      SqlParser.get[UUID](pkField) ~
-      SqlParser.get[String](referenceField) ~
-      SqlParser.get[Option[LocalDateTime]](expirationField) ~
-      SqlParser.get[UUID](ownerField) ~
-      SqlParser.get[UUID](fsNodeField) ~
-      SqlParser.get[ByteString](encryptedPrivateKeyField) ~
-      SqlParser.get[ByteString](privateKeySaltField) ~
-      SqlParser.get[ByteString](salt1Field) ~
-      SqlParser.get[ByteString](ivField) ~
-      SqlParser.get[ByteString](secretCodeHashField) ~
-      SqlParser.get[ByteString](salt2Field)
-    ).map {
-      case id ~ reference ~ expiration ~ owner ~ fsNode ~ encryptedPrivateKey ~ privateKeySalt ~ salt1 ~ iv ~ secretCodeHash ~ salt2 =>
-        val sharingSecurity = SharingSecurity(
-          encryptedPrivateKey,
-          privateKeySalt,
-          salt1,
-          iv,
-          secretCodeHash,
-          salt2
-        )
+    implicit def sharingColumn: Column[Sharing] = AnormSupport.column[Sharing](Sharing.internalFormat)
 
-        Sharing(id, reference, expiration, owner, fsNode, sharingSecurity)
-    }
+    SqlParser.get[Sharing]("metadata")
   }
 
   def getParams(sharing: Sharing): Seq[NamedParameter] = {
     Seq(
       'id                  -> sharing.id,
       'reference           -> sharing.reference,
-      'expiration          -> sharing.expiration,
       'user_id             -> sharing.owner,
       'fsNode_id           -> sharing.fsNode,
-      'encryptedPrivateKey -> sharing.security.encryptedPrivateKey,
-      'privateKeySalt      -> sharing.security.privateKeySalt,
-      'salt1               -> sharing.security.salt1,
-      'iv                  -> sharing.security.iv,
-      'secretCodeHash      -> sharing.security.secretCodeHash,
-      'salt2               -> sharing.security.salt2
+      'metadata            -> Sharing.internalFormat.writes(sharing)
     )
   }
 }
@@ -208,16 +138,10 @@ object SharingStore {
 
   val table: String = "sharing"
 
-  val pkField: String                  = "id"
-  val referenceField: String           = "reference"
-  val expirationField: String          = "expiration"
-  val ownerField: String               = "user_id"
-  val fsNodeField: String              = "fsNode_id"
-  val encryptedPrivateKeyField: String = "encryptedPrivateKey"
-  val privateKeySaltField: String      = "privateKeySalt"
-  val salt1Field: String               = "salt1"
-  val ivField: String                  = "iv"
-  val secretCodeHashField: String      = "secretCodeHash"
-  val salt2Field: String               = "salt2"
+  val pkField: String        = "id"
+  val referenceField: String = "reference"
+  val ownerField: String     = "user_id"
+  val fsNodeField: String    = "fsNode_id"
+  val metadataField: String  = "metadata"
 
 }


### PR DESCRIPTION
Change le mode de fonctionnement du système de chiffrage pour utiliser une clef de chiffrement par fichier plutôt qu'une seule clef globale. Le partage utilise alors une version chiffrée de cette clef privée du fichier (avec la clef de partage), au lieu de la clef globale. Ainsi, même avec une clef de partage et la base, il est seulement possible d’accéder au même fichier qu'avec le partage et non plus tout les fichiers comme avant.

Contrainte : le partage de dossier est pour le moment désactivé, et ne pourra pas être dynamique.